### PR TITLE
Support additional argument type in UsersUAA.decodeAccessToken().

### DIFF
--- a/lib/model/uaa/UsersUAA.js
+++ b/lib/model/uaa/UsersUAA.js
@@ -203,6 +203,8 @@ class UsersUAA {
 
      decodeAccessToken (accessToken) {
         var tokenString;
+        if(typeof accessToken !== 'string')
+            accessToken = accessToken.access_token
         var bearerTypeAndToken = accessToken.split(" ")
         if (bearerTypeAndToken.length === 2) {
             tokenString = bearerTypeAndToken[1]


### PR DESCRIPTION
this is a not-great fix, but we don't have typescript available...
