### PR TITLE
Decode the Protocol Buffers from the loggregator

### DIFF
--- a/lib/model/metrics/Logs.js
+++ b/lib/model/metrics/Logs.js
@@ -4,6 +4,12 @@ const HttpUtils = require("../../utils/HttpUtils");
 const HttpStatus = require("../../utils/HttpStatus");
 const ws = require('ws');
 
+const path = require("path");
+const builder = require("protobufjs").loadProtoFile(path.join(__dirname, "log_message.proto"));
+
+//Build the logmessage package from the log_message.proto file
+const LOG_MESSAGE = builder.build("logmessage");
+
 /**
  * Manage Logs in Cloud Foundry
  * {@link https://docs.pivotal.io/pivotalcf/devguide/deploy-apps/streaming-logs.html}
@@ -57,10 +63,23 @@ class Logs {
                 'transfer-encoding': '',
                 'Authorization': `${this.UAA_TOKEN.token_type} ${this.UAA_TOKEN.access_token}`,
                 'Content-Type': 'text'
-            }
+            },
+            encoding: null
         };
 
-        return this.REST.request(options, this.HttpStatus.OK, false);
+        return this.REST.request(options, this.HttpStatus.OK, false).then((response) => {
+          //The response is an array of protocol buffer encoded messages
+            return response.map((message) => {
+                //For each message, decode it and also convert the binary text to a string
+                const $message = LOG_MESSAGE.LogMessage.decode(message);
+
+                //message is a buffer, convert to a string for simplicity
+                $message.message = $message.message.toString("utf8");
+                //Came across the division by 1e6 on Bluemix.
+                $message.timestamp = $message.timestamp.toNumber() / 1e6;
+                return $message;
+            }).sort((l, r) => l.timestamp - r.timestamp);
+        });
     }
 
 }

--- a/lib/model/metrics/log_message.proto
+++ b/lib/model/metrics/log_message.proto
@@ -1,0 +1,23 @@
+package logmessage;
+
+message LogMessage {
+    enum MessageType {
+        OUT = 1;
+        ERR = 2;
+    }
+
+    required bytes message = 1;
+    required MessageType message_type = 2;
+    required sint64 timestamp = 3;
+    required string app_id = 4;
+    optional string source_id = 6;
+    repeated string drain_urls = 7;
+    optional string source_name = 8;
+}
+
+message LogEnvelope {
+    required string routing_key = 1;
+    required bytes signature = 2;
+    required LogMessage log_message = 3;
+}
+

--- a/lib/utils/HttpUtils.js
+++ b/lib/utils/HttpUtils.js
@@ -60,7 +60,7 @@ class HttpUtils {
                             return reject(body);
                         }
                     } else {
-                        const boundaryMatch = response.headers["content-type"].match("boundary=(.*)");
+                        const boundaryMatch = (response.headers["content-type"] || "").match("boundary=(.*)");
 
                         if (boundaryMatch) {
                             //It's multipart data. Join it together into a single array

--- a/lib/utils/HttpUtils.js
+++ b/lib/utils/HttpUtils.js
@@ -60,7 +60,26 @@ class HttpUtils {
                             return reject(body);
                         }
                     } else {
-                        result = body;
+                        const boundaryMatch = response.headers["content-type"].match("boundary=(.*)");
+
+                        if (boundaryMatch) {
+                            //It's multipart data. Join it together into a single array
+                            const boundary = `--${boundaryMatch[1]}`;
+                            const respBuffers = [];
+
+                            let idx = body.indexOf(boundary);
+                            let lastIdx = idx;
+
+                            while ((idx = body.indexOf(boundary, lastIdx + boundary.length)) > -1) {
+                                //Trim off the \r\n, and start after the boundary accounting for \r\n\r\n
+                                respBuffers.push(body.slice(lastIdx + boundary.length + "\r\n\r\n".length, idx - "\r\n".length));
+                                lastIdx = idx;
+                            }
+
+                            result = respBuffers;
+                        } else {
+                            result = body;
+                        }
                     }
 
                     if (!error && response.statusCode === httpStatusAssert) {

--- a/lib/utils/HttpUtils.js
+++ b/lib/utils/HttpUtils.js
@@ -65,6 +65,8 @@ class HttpUtils {
                         if (boundaryMatch) {
                             //It's multipart data. Join it together into a single array
                             const boundary = `--${boundaryMatch[1]}`;
+                            const linearWhitespaceLength = "\r\n\r\n".length;
+                            const terminatingWhitespaceLength = "\r\n".length;
                             const respBuffers = [];
 
                             let idx = body.indexOf(boundary);
@@ -72,7 +74,7 @@ class HttpUtils {
 
                             while ((idx = body.indexOf(boundary, lastIdx + boundary.length)) > -1) {
                                 //Trim off the \r\n, and start after the boundary accounting for \r\n\r\n
-                                respBuffers.push(body.slice(lastIdx + boundary.length + "\r\n\r\n".length, idx - "\r\n".length));
+                                respBuffers.push(body.slice(lastIdx + boundary.length + linearWhitespaceLength, idx - terminatingWhitespaceLength));
                                 lastIdx = idx;
                             }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "bluebird": "3.0.6",
+    "protobufjs": "5.0.1",
     "request": "2.67.0",
     "restler": "3.4.0",
     "ws": "1.1.0"


### PR DESCRIPTION
In using the API, I noticed that the results of `getRecent` came back with text that didn't look very great. This PR aim to address this by decoding the multipart protocol buffer returned from the loggregator API request, and in the end provides an array of message objects conforming to the protocol definition provided by cloud foundry https://github.com/cloudfoundry/loggregatorlib/blob/master/logmessage/log_message.proto
