### PR TITLE
Accept ReadableStreams as a way of uploading applications

### DIFF
--- a/lib/model/cloudcontroller/Apps.js
+++ b/lib/model/cloudcontroller/Apps.js
@@ -5,15 +5,6 @@ const rest = require("restler");//TODO: Analyze a way to remove this dependency
 const fs = require("fs");
 
 /**
- * Is it a ReadableStream?
- * @param {Object} [source] the source of information
- * @returns {Boolean} true is the argument is a ReadableStream; otherwise, false
- */
-function isReadableStream(source) {
-    return source && typeof source.pipe === 'function';
-}
-
-/**
  * This public class manages the operations related with Applications on Cloud Controller.
  */
 class Apps extends CloudControllerBase {
@@ -301,12 +292,12 @@ class Apps extends CloudControllerBase {
      * function File(path, filename, fileSize, encoding, contentType)
      * 'application': rest.file(path, null, fileSizeInBytes, null, 'application/zip')
      *
-     * @param  {String} appGuid                          [App guid]
-     * @param  {String|stream.ReadableStream} source     [file path or readable stream to upload]
-     * @param  {Boolean} async                           [Sync/Async]
-     * @return {JSON/String}                             [{}/Job information]
+     * @param  {String} appGuid     [App guid]
+     * @param  {String} filePath     [file path to upload]
+     * @param  {Boolean} async        [Sync/Async]
+     * @return {JSON/String}              [{}/Job information]
      */
-    upload (appGuid, source, async) {
+    upload (appGuid, filePath, async) {
 
         const url = `${this.API_URL}/v2/apps/${appGuid}/bits`;
         const zipResources = [];
@@ -318,36 +309,60 @@ class Apps extends CloudControllerBase {
                 asyncFlag = true;
             }
         }
-
-        let promise;
-        if (typeof source === "string" || isReadableStream(source)) {
-            let options = {
-              headers: {
-                  Authorization: `${this.UAA_TOKEN.token_type} ${this.UAA_TOKEN.access_token}`
-              },
-              qs: {
-                  async: asyncFlag
-              }
-            };
-            promise = this.REST.uploadStream(url, options, typeof source === "string" ? fs.createReadStream(source) : source, this.HttpStatus.CREATED, false);
-        } else {
-            let options = {
-              multipart: true,
-              data: {
-                  resources: JSON.stringify(zipResources)
-              },
-              application: rest.data(null, "application/zip", source.toBuffer()),
-              query: {
-                  guid: appGuid,
-                  async: asyncFlag
-              }
+        var options = {
+            multipart: true,
+            accessToken: this.UAA_TOKEN.access_token,
+            query: {
+                guid: appGuid,
+                async: asyncFlag
+            },
+            data: {
+                resources: JSON.stringify(zipResources)
             }
-            promise = this.REST.upload(url, options, this.HttpStatus.CREATED, false);
+        };
+
+        if (typeof filePath === "string") {
+            stats = fs.statSync(filePath);
+            options.data.application = rest.file(filePath, null, stats.size, null, "application/zip");
+        } else {
+            options.data.application = rest.data(null, "application/zip", filePath.toBuffer());
         }
 
-        return promise;
+        return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
     }
 
+    /**
+     * Upload source code from a ReadableStream
+     * {@link http://apidocs.cloudfoundry.org/214/apps/uploads_the_bits_for_an_app.html}
+     *
+     *
+     * @param  {String} appGuid                   [App guid]
+     * @param  {stream.ReadableStream} stream     [stream to upload]
+     * @param  {Boolean} async                    [Sync/Async]
+     * @return {JSON/String}                      [{}/Job information]
+     */
+    uploadFromStream (appGuid, stream, async) {
+
+        const url = `${this.API_URL}/v2/apps/${appGuid}/bits`;
+        const zipResources = [];
+        let asyncFlag = false;
+        var stats = null;
+
+        if (typeof async === "boolean") {
+            if (async) {
+                asyncFlag = true;
+            }
+        }
+        let options = {
+            headers: {
+                Authorization: `${this.UAA_TOKEN.token_type} ${this.UAA_TOKEN.access_token}`
+            },
+            qs: {
+                async: asyncFlag
+            }
+        };
+        return this.REST.uploadStream(url, options, stream, this.HttpStatus.CREATED, false);
+    }
 
     /**
      * Get Instances

--- a/lib/model/cloudcontroller/Apps.js
+++ b/lib/model/cloudcontroller/Apps.js
@@ -5,6 +5,15 @@ const rest = require("restler");//TODO: Analyze a way to remove this dependency
 const fs = require("fs");
 
 /**
+ * Is it a ReadableStream?
+ * @param {Object} [source] the source of information
+ * @returns {Boolean} true is the argument is a ReadableStream; otherwise, false
+ */
+function isReadableStream(source) {
+    return source && typeof source.pipe === 'function';
+}
+
+/**
  * This public class manages the operations related with Applications on Cloud Controller.
  */
 class Apps extends CloudControllerBase {
@@ -292,12 +301,12 @@ class Apps extends CloudControllerBase {
      * function File(path, filename, fileSize, encoding, contentType)
      * 'application': rest.file(path, null, fileSizeInBytes, null, 'application/zip')
      *
-     * @param  {String} appGuid     [App guid]
-     * @param  {String} filePath     [file path to upload]
-     * @param  {Boolean} async        [Sync/Async]
-     * @return {JSON/String}              [{}/Job information]
+     * @param  {String} appGuid                          [App guid]
+     * @param  {String|stream.ReadableStream} source     [file path or readable stream to upload]
+     * @param  {Boolean} async                           [Sync/Async]
+     * @return {JSON/String}                             [{}/Job information]
      */
-    upload (appGuid, filePath, async) {
+    upload (appGuid, source, async) {
 
         const url = `${this.API_URL}/v2/apps/${appGuid}/bits`;
         const zipResources = [];
@@ -309,26 +318,34 @@ class Apps extends CloudControllerBase {
                 asyncFlag = true;
             }
         }
-        var options = {
-            multipart: true,
-            accessToken: this.UAA_TOKEN.access_token,
-            query: {
-                guid: appGuid,
-                async: asyncFlag
-            },
-            data: {
-                resources: JSON.stringify(zipResources)
-            }
-        };
 
-        if (typeof filePath === "string") {
-            stats = fs.statSync(filePath);
-            options.data.application = rest.file(filePath, null, stats.size, null, "application/zip");
+        let promise;
+        if (typeof source === "string" || isReadableStream(source)) {
+            let options = {
+              headers: {
+                  Authorization: `${this.UAA_TOKEN.token_type} ${this.UAA_TOKEN.access_token}`
+              },
+              qs: {
+                  async: asyncFlag
+              }
+            };
+            promise = this.REST.uploadStream(url, options, typeof source === "string" ? fs.createReadStream(source) : source, this.HttpStatus.CREATED, false);
         } else {
-            options.data.application = rest.data(null, "application/zip", filePath.toBuffer());
+            let options = {
+              multipart: true,
+              data: {
+                  resources: JSON.stringify(zipResources)
+              },
+              application: rest.data(null, "application/zip", source.toBuffer()),
+              query: {
+                  guid: appGuid,
+                  async: asyncFlag
+              }
+            }
+            promise = this.REST.upload(url, options, this.HttpStatus.CREATED, false);
         }
 
-        return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
+        return promise;
     }
 
 

--- a/lib/utils/HttpUtils.js
+++ b/lib/utils/HttpUtils.js
@@ -140,6 +140,61 @@ class HttpUtils {
 
         });
     }
+
+    /**
+     * Method designed to upload a stream of a zip to Cloud Controller.
+     *
+     * @param  {string} url                   [url]
+     * @param  {json} options                 [options]
+     * @param  {stream.ReadableStream} stream [the readable stream for the zip file]
+     * @param  {number} httpStatusAssert      [set expected http status code (200,201,204, etc...)]
+     * @param  {boolan} jsonOutput            [if the REST method retuns a String or a JSON representation]
+     * @return {string}                       [JSON/String]
+     */
+    uploadStream(url, options, stream, httpStatusAssert, jsonOutput) {
+
+        return new Promise(function (resolve, reject) {
+
+            try {
+                const uploadOptions = {
+                    rejectUnauthorized: false,
+                    formData: {
+                      resources: "[]",
+                      application: stream
+                    }
+                };
+                Object.keys(options).forEach(function (key) {
+                  uploadOptions[key] = options[key];
+                });
+
+                request.put(url, uploadOptions, function (error, response, body) {
+                    if (error) {
+                        return reject(error);
+                    }
+
+                    if (response.statusCode === httpStatusAssert) {
+
+                        if (jsonOutput) {
+                            try {
+                                resolve(JSON.parse(body));
+                            }
+                            catch (errorJSON) {
+                                reject(body);
+                            }
+                        }
+
+                        resolve(body);
+                    } else {
+                        reject(body);
+                    }
+                });
+
+            } catch (error) {
+                reject(error);
+            }
+
+        });
+    }
 }
 
 module.exports = HttpUtils;


### PR DESCRIPTION
In this change, I've added support for a ReadableStream being the source for an application upload. The use case would be that we may already have a stream available to us without having a local resource that can be accessed by a filepath.
