### PR TITLE
Adding support to set Custom Request Objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The development has been tested with:
 
 | [Local Instance](https://github.com/yudai/cf_nise_installer) | [PWS](https://console.run.pivotal.io)           | [Bluemix](https://console.ng.bluemix.net/) |
 | -------------- |:-------------:| -------:|
-| 2.25.0         | 2.47.0        | 2.40.0  |
+| 2.25.0         | 2.60.0        | 2.54.0  |
 
 **Last test:** 2016/01/26
 

--- a/lib/model/cloudcontroller/CloudControllerBase.js
+++ b/lib/model/cloudcontroller/CloudControllerBase.js
@@ -39,6 +39,15 @@ class CloudControllerBase {
 
         this.UAA_TOKEN = token;
     }
+
+    /**
+     * Set a Custom requestObject
+     * @param {[type]} requestObj [description]
+     */
+    setCustomRequestObject(requestObj){
+
+        this.REST.setCustomRequestObject(requestObj);
+    }
 }
 
 module.exports = CloudControllerBase;

--- a/lib/utils/HttpUtils.js
+++ b/lib/utils/HttpUtils.js
@@ -17,7 +17,17 @@ class HttpUtils {
      * @returns {void}
      */
     constructor() {
+        this.requestObj = request;
+    }
 
+    /**
+     * Method designed to set a Custom request object.
+     * https://github.com/request/request
+     *
+     * @param {[type]} requestObj [description]
+     */
+    setCustomRequestObject(requestObj){
+        this.requestObj = requestObj;
     }
 
     /**
@@ -39,16 +49,13 @@ class HttpUtils {
     request (options, httpStatusAssert, jsonOutput) {
         let result = null;
 
-        //process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-        const requestWithDefaults = request.defaults({
-            rejectUnauthorized: false
-        });
+        let request = this.requestObj;
 
         return new Promise(function (resolve, reject) {
 
             try {
 
-                requestWithDefaults(options, function (error, response, body) {
+                request(options, function (error, response, body) {
                     if (error) {
                         return reject(error);
                     }
@@ -152,6 +159,8 @@ class HttpUtils {
      * @return {string}                       [JSON/String]
      */
     uploadStream(url, options, stream, httpStatusAssert, jsonOutput) {
+
+        let request = this.requestObj;
 
         return new Promise(function (resolve, reject) {
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test": "npm run lint && npm run test:bluemix",
     "test:local": "mocha test --config=LOCAL_INSTANCE_1",
     "test:pws": "mocha test --config=PIVOTAL",
-    "test:bluemix": "mocha test --config=BLUEMIX",
-    "uml": "node ./node_modules/wavi/bin/wavi --png ./lib/ ./docs/umlDiagram.png --includenodemodules"
+    "test:bluemix": "mocha test --config=BLUEMIX"
   },
   "homepage": "https://github.com/IBM-Bluemix/cf-nodejs-client",
   "repository": {
@@ -48,8 +47,7 @@
     "mocha": "2.3.4",
     "nconf": "0.8.2",
     "optimist": "0.6.1",
-    "random-words": "0.0.1",
-    "wavi": "0.2.16"
+    "random-words": "0.0.1"
   },
   "keywords": [
     "cloud foundry",

--- a/test/lib/model/cloudcontroller/CloudControllerTests.js
+++ b/test/lib/model/cloudcontroller/CloudControllerTests.js
@@ -22,6 +22,8 @@ var CloudFoundryUsersUAA = require("../../../../lib/model/uaa/UsersUAA");
 CloudController = new CloudController();
 CloudFoundryUsersUAA = new CloudFoundryUsersUAA();
 
+const request = require("request");
+
 describe("Cloud Controller", function () {
 
     var authorization_endpoint = null;
@@ -81,5 +83,30 @@ describe("Cloud Controller", function () {
         });
 
     }
+
+    it("Set Custom request object", function () {
+
+        //process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+        const requestWithDefaults = request.defaults({
+            rejectUnauthorized: false
+        });
+
+        CloudController.setCustomRequestObject(requestWithDefaults);
+        return CloudController.getFeaturedFlags().then(function (result) {
+            return expect(true).to.be.a('boolean');
+        });
+    });
+
+    it.skip("Set Bad Custom request object", function () {
+
+        const badRequestConfiguration = request.defaults({
+            proxy: 'http://localproxy.com'
+        });
+
+        CloudController.setCustomRequestObject(badRequestConfiguration);
+        return CloudController.getFeaturedFlags().then(function (result) {
+            return expect(true).to.be.a('boolean');
+        });
+    });
 
 });

--- a/test/utils/HttpUtilsTests.js
+++ b/test/utils/HttpUtilsTests.js
@@ -5,6 +5,7 @@
 var chai = require("chai"),
     expect = require("chai").expect;
 
+const request = require("request");
 var HttpUtils = require('../../lib/utils/HttpUtils');
 HttpUtils = new HttpUtils();
 
@@ -50,6 +51,45 @@ describe("HttpUtils", function () {
             url: url
         };
 
+        return HttpUtils.request(options, 404, false).then(function (result) {
+            expect(result).is.a("string");
+        });
+    });
+
+    it("Set request defaults", function () {
+        this.timeout(15000);
+
+        var url = "https://api.run.pivotal.io/v22/info";
+        var options = {
+            method: 'GET',
+            url: url
+        };
+
+        //process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+        const requestWithDefaults = request.defaults({
+            rejectUnauthorized: false
+        });
+
+        HttpUtils.setCustomRequestObject(requestWithDefaults);
+        return HttpUtils.request(options, 404, false).then(function (result) {
+            expect(result).is.a("string");
+        });
+    });
+
+    it.skip("Set a bad defaults request", function () {
+        this.timeout(15000);
+
+        var url = "https://api.run.pivotal.io/v22/info";
+        var options = {
+            method: 'GET',
+            url: url
+        };
+
+        const badRequestConfiguration = request.defaults({
+            proxy: 'http://localproxy.com'
+        });
+
+        HttpUtils.setCustomRequestObject(badRequestConfiguration);
         return HttpUtils.request(options, 404, false).then(function (result) {
             expect(result).is.a("string");
         });


### PR DESCRIPTION
Currently, the library doesn`t have support in case of any consumer has to run the system in a environment which it requires a Proxy for example. Request object, incorporates a way to set default configuration.
https://github.com/request/request

The low level class: HttpUtils, has a default configuration used with Yudai CF installation because it uses a self signed certificated. 
https://github.com/yudai/cf_nise_installer

The elegant way is to set in a manual way that configuration:

``` js
        //process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
        const requestWithDefaults = request.defaults({
            rejectUnauthorized: false
        });
```
I have just removed that block from HttpUtils, it is not necessary to interact with PWS or Bluemix. Besides I unified the object used for both methods: 

- request
- uploadStream

I added some examples at different levels.

Note: uploadStream is fantastic.

Cheers

Juan Antonio