### PR TITLE
Update "request" version to avoid security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-client",
-  "version": "0.13.26",
+  "version": "0.13.27",
   "description": "A Cloud Foundry Client for Node.js",
   "author": "Juan Antonio Breña Moral <bren@juanantonio.info>",
   "license": "Apache-2.0",
@@ -33,7 +33,7 @@
   "dependencies": {
     "bluebird": "3.0.6",
     "protobufjs": "5.0.1",
-    "request": "2.67.0",
+    "request": "2.81.0",
     "restler": "3.4.0",
     "ws": "1.1.1"
   },


### PR DESCRIPTION
Update "request" version to avoid dependency on vulnerable tough-cookie version: 

npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130