### PR TITLE
Allow dependencies to upgrade with non-breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-client",
-  "version": "0.13.26",
+  "version": "0.13.27",
   "description": "A Cloud Foundry Client for Node.js",
   "author": "Juan Antonio Breña Moral <bren@juanantonio.info>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "lib"
   ],
   "dependencies": {
-    "bluebird": "3.0.6",
-    "protobufjs": "5.0.1",
-    "request": "2.67.0",
-    "restler": "3.4.0",
-    "ws": "1.1.1"
+    "bluebird": "^3.0.6",
+    "protobufjs": "^5.0.1",
+    "request": "^2.67.0",
+    "restler": "^3.4.0",
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "archiver": "0.20.0",


### PR DESCRIPTION
Following a chat on https://github.com/IBM-Cloud/cf-nodejs-client/pull/46#issuecomment-449869496, applying `^` to production dependencies' versions to remove vulnerabilities introduced by dependencies.

Before: http://snyk.io/test/github/IBM-Cloud/cf-nodejs-client
After: http://snyk.io/test/github/adrukh/cf-nodejs-client